### PR TITLE
Better capturing and handling of test failures

### DIFF
--- a/ftests.sh
+++ b/ftests.sh
@@ -1,4 +1,13 @@
-#!/bin/sh
+#!/bin/bash
+
+errors=0
+
+# Verify that the ZEROVM_ROOT var is set:
+env | grep -q ^ZEROVM_ROOT=
+if [ $? -ne 0 ]; then
+    echo "Error: ZEROVM_ROOT variable is not set"
+    exit 1
+fi
 
 cd $ZEROVM_ROOT/tests/functional/include
 make -s clean all
@@ -9,6 +18,18 @@ for i in `find $ZEROVM_ROOT/tests -type d`; do
   fi
     cd $i
     if [ -f ./test.sh ]; then
-        ./test.sh
+        output=`./test.sh`
+        # check for and count failures
+        if [[ $? -eq 1 || `echo "$output" | grep "failed"` ]]; then
+            errors=`expr $errors + 1`
+        fi
+        printf "$output\n"
     fi
 done
+
+if [ $errors -gt 0 ]; then
+    # If any of the tests failed,
+    # make sure we don't falsely return a 0 exit status
+    echo "There were $errors errors"
+    exit 1
+fi


### PR DESCRIPTION
ftests.sh runs a series of tests. There was a problem, however, that
made the test script exit with a 0 status even when there were
failures. The reason for this is because the tests exist in separate
files, and ftests.sh ignores the exit code when it calls each script. I
discovered this when I got a false positive in a CI build.

This change fixes all of that and properly captures the exit codes. If
there are any test failures, ftests.sh will print an error message and
exit with a status of 1.

Please let me know what you think. Thanks!
