### PR TITLE
Makefile: remove unnecessary setting of DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 PREFIX ?= /usr/local
-DESTDIR ?=
 prefix = $(PREFIX)
 exec_prefix = $(prefix)
 bindir = $(exec_prefix)/bin


### PR DESCRIPTION
Using an undefined variable is not an error -- the variable is simply
replaced by the empty string. The GNU Coding Standards concurs:

  You should not set the value of DESTDIR in your Makefile at all;
  then the files are installed into their expected locations by
  default. Also, specifying DESTDIR should not change the operation of
  the software in any way, so its value should not be included in any
  file contents.

  http://www.gnu.org/prep/standards/html_node/DESTDIR.html
