### PR TITLE
Remove silent-by-default CC and CXX variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,6 @@ debug: CXXFLAGS2 := -DDEBUG -g $(CXXFLAGS2)
 debug: create_dirs zerovm tests
 
 OBJS=obj/elf_util.o obj/gio.o obj/gio_snapshot.o obj/manifest.o obj/setup.o obj/channel.o obj/qualify.o obj/report.o obj/zlog.o obj/signal_common.o obj/signal.o obj/to_app.o obj/switch_to_app.o obj/to_trap.o obj/syscall_hook.o obj/prefetch.o obj/nservice.o obj/preload.o obj/sel_addrspace.o obj/sel_ldr.o obj/sel.o obj/sel_memory.o obj/sel_rt.o obj/tramp.o obj/trap.o obj/etag.o obj/accounting.o obj/daemon.o obj/snapshot.o
-CC=@gcc
-CXX=@g++
 
 create_dirs:
 	@mkdir obj -p


### PR DESCRIPTION
I find it strange and annoying that 'make all' has no output. The
default behavior might be too verbose, but it's standard and deviating
too fra from it is not helpful.
