### PR TITLE
debian/control: rename/update libvalidator0 dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: zerovm-zmq
 Section: otherosfs
 Priority: extra
 Maintainer: Lars Butler <Lars.Butler@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), pkg-config, libvalidator0, libzmq3-dev (>= 4.0.1), libglib2.0-dev
+Build-Depends: debhelper (>= 8.0.0), pkg-config, zvm-validator, libzmq3-dev (>= 4.0.1), libglib2.0-dev
 Standards-Version: 3.9.3
 Homepage: http://www.zerovm.org
 


### PR DESCRIPTION
debian/control: rename/update libvalidator0 dep

The `libvalidator0` package has been renamed to `zvm-validator`. This
change simply updates the Build-Depends list to require `zvm-validator`.
