### PR TITLE
deleted debian log files

### DIFF
--- a/debian/zerovm-zmq-dbg.debhelper.log
+++ b/debian/zerovm-zmq-dbg.debhelper.log
@@ -1,1 +1,0 @@
-dh_auto_configure

--- a/debian/zerovm-zmq-dev.debhelper.log
+++ b/debian/zerovm-zmq-dev.debhelper.log
@@ -1,1 +1,0 @@
-dh_auto_configure

--- a/debian/zerovm-zmq.debhelper.log
+++ b/debian/zerovm-zmq.debhelper.log
@@ -1,1 +1,0 @@
-dh_auto_configure


### PR DESCRIPTION
debuild log files do not need to be in repository
